### PR TITLE
Adding missing day to calendar.

### DIFF
--- a/datePicker.js
+++ b/datePicker.js
@@ -244,7 +244,7 @@ DatePicker.prototype.build = {
         }
         
         // Build days
-        for ( var i=1; i<howManyDays; i++ ) {
+        for ( var i=1; i<=howManyDays; i++ ) {
             if(i == that.config.currentDay 
                 && that.config.selected.year == that.config.currentYear
                 && that.config.selected.month == that.config.currentMonth) {


### PR DESCRIPTION
A day is missing on the calendar.  For example, April only shows 29 days.  This fixes it.
